### PR TITLE
Add Twilio client factory and webhook signature verification

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,18 @@
 const express = require('express');
 const tenantResolver = require('./lib/tenantResolver');
+const { verifyTwilioSignature } = require('./services/security');
 
 const app = express();
 
+// parse incoming webhook bodies
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
+
 // resolve tenant from header before handling routes
 app.use(tenantResolver);
+
+// verify twilio requests for webhook endpoints
+app.use('/webhooks', verifyTwilioSignature);
 
 // routes would be added below
 module.exports = app;

--- a/server/services/security.js
+++ b/server/services/security.js
@@ -1,0 +1,25 @@
+const twilio = require('twilio');
+
+/**
+ * Express middleware verifying incoming Twilio webhook requests using the
+ * X-Twilio-Signature header and the tenant's auth token.
+ */
+function verifyTwilioSignature(req, res, next) {
+  const token = req.tenant?.twilioAuthToken || req.tenant?.authToken || process.env.TWILIO_AUTH_TOKEN;
+  if (!token) {
+    return res.status(500).send('Twilio auth token not configured');
+  }
+
+  const signature = req.header('X-Twilio-Signature');
+  const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+  const params = req.body || {};
+
+  const valid = twilio.validateRequest(token, signature, url, params);
+  if (!valid) {
+    return res.status(403).send('Invalid Twilio signature');
+  }
+
+  return next();
+}
+
+module.exports = { verifyTwilioSignature };

--- a/server/services/twilio.js
+++ b/server/services/twilio.js
@@ -1,0 +1,20 @@
+const twilio = require('twilio');
+
+/**
+ * Create Twilio REST clients for a tenant.
+ * @param {Object} tenant - Tenant configuration containing Twilio credentials.
+ * @returns {Object} Object containing the Twilio client instance.
+ */
+function makeTwilioClients(tenant = {}) {
+  const accountSid = tenant.twilioAccountSid || tenant.accountSid;
+  const authToken = tenant.twilioAuthToken || tenant.authToken;
+
+  if (!accountSid || !authToken) {
+    throw new Error('Twilio credentials are not configured for tenant');
+  }
+
+  const client = twilio(accountSid, authToken);
+  return { client };
+}
+
+module.exports = { makeTwilioClients };


### PR DESCRIPTION
## Summary
- create Twilio client factory for tenant-specific credentials
- add middleware verifying Twilio webhook signatures
- secure `/webhooks/*` routes with signature verification

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -e "require('./server/services/security');"`

------
https://chatgpt.com/codex/tasks/task_e_68a1353a553c832aa7ce62445598a087