### PR TITLE
Add auth utilities, RBAC middleware, CORS and rate limiting

### DIFF
--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -1,0 +1,36 @@
+const jwt = require('jsonwebtoken');
+
+// helper to sign JWTs with a shared secret
+const secret = process.env.JWT_SECRET || 'changeme';
+
+function sign(payload, options = {}) {
+  return jwt.sign(payload, secret, { expiresIn: '1h', ...options });
+}
+
+function verify(token) {
+  try {
+    return jwt.verify(token, secret);
+  } catch (err) {
+    return null;
+  }
+}
+
+// middleware to authenticate requests using Authorization: Bearer <token>
+function auth(req, res, next) {
+  const header = req.headers.authorization || '';
+  const [scheme, token] = header.split(' ');
+
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const decoded = verify(token);
+  if (!decoded) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  req.user = decoded;
+  next();
+}
+
+module.exports = { sign, verify, auth };

--- a/server/lib/cors.js
+++ b/server/lib/cors.js
@@ -1,0 +1,21 @@
+const cors = require('cors');
+
+const whitelist = [
+  'http://localhost:3000',
+  'http://localhost:3001',
+  process.env.CLIENT_URL,
+].filter(Boolean);
+
+const corsOptions = {
+  origin: function (origin, callback) {
+    if (!origin || whitelist.indexOf(origin) !== -1) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+};
+
+module.exports = cors(corsOptions);
+module.exports.corsOptions = corsOptions;

--- a/server/lib/rateLimit.js
+++ b/server/lib/rateLimit.js
@@ -1,0 +1,10 @@
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+module.exports = limiter;

--- a/server/lib/rbac.js
+++ b/server/lib/rbac.js
@@ -1,0 +1,19 @@
+function requireRole(role) {
+  return (req, res, next) => {
+    const user = req.user;
+    const roles = user && (user.roles || user.role);
+
+    // roles may be array or single value
+    const hasRole = Array.isArray(roles)
+      ? roles.includes(role)
+      : roles === role;
+
+    if (!hasRole) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    next();
+  };
+}
+
+module.exports = { requireRole };


### PR DESCRIPTION
## Summary
- add JWT sign/verify helpers and auth middleware
- add role-based access control middleware
- configure CORS for localhost development
- introduce sensible express rate limiting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1365d6a28832a82fb51854f95007e