### PR TITLE
Add basic MongoDB models for customers, agents, and conversations

### DIFF
--- a/server/models/Agent.js
+++ b/server/models/Agent.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const AgentSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  passwordHash: { type: String, required: true },
+  skills: [String],
+  roles: [String],
+}, { timestamps: true });
+
+module.exports = mongoose.model('Agent', AgentSchema);

--- a/server/models/ConversationState.js
+++ b/server/models/ConversationState.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const ConversationStateSchema = new mongoose.Schema({
+  conversationId: { type: String, required: true, unique: true },
+  attributes: { type: mongoose.Schema.Types.Mixed },
+  locked: { type: Boolean, default: false },
+}, { timestamps: true });
+
+module.exports = mongoose.model('ConversationState', ConversationStateSchema);

--- a/server/models/Customer.js
+++ b/server/models/Customer.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const AddressSchema = new mongoose.Schema({
+  line1: String,
+  line2: String,
+  city: String,
+  state: String,
+  postalCode: String,
+  country: String,
+}, { _id: false });
+
+const OrderSchema = new mongoose.Schema({
+  productId: String,
+  quantity: Number,
+  price: Number,
+  status: String,
+  createdAt: { type: Date, default: Date.now },
+}, { _id: false });
+
+const CustomerSchema = new mongoose.Schema({
+  profile: {
+    firstName: String,
+    lastName: String,
+    email: { type: String, required: true },
+    phone: String,
+  },
+  addresses: [AddressSchema],
+  orders: [OrderSchema],
+}, { timestamps: true });
+
+module.exports = mongoose.model('Customer', CustomerSchema);


### PR DESCRIPTION
## Summary
- add Mongoose model for customers with profile, addresses, and orders
- add agent model capturing login credentials, skills, and roles
- add conversation state model tracking attributes and lock state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1376338f8832aa8baefbc5678e571