### PR TITLE
feat: add CRM and state management services

### DIFF
--- a/server/services/crm.js
+++ b/server/services/crm.js
@@ -1,0 +1,37 @@
+let fetchFn = global.fetch;
+if (!fetchFn) {
+  try {
+    fetchFn = require('node-fetch');
+  } catch (err) {
+    throw new Error('Fetch API not available');
+  }
+}
+
+async function request(tenant = {}, path = '') {
+  const baseUrl = tenant.crmBaseUrl || process.env.CRM_BASE_URL;
+  if (!baseUrl) {
+    throw new Error('CRM base URL is not configured');
+  }
+  const apiKey = tenant.crmApiKey || process.env.CRM_API_KEY;
+  const url = `${baseUrl}${path}`;
+  const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+  const res = await fetchFn(url, { headers });
+  if (!res.ok) {
+    throw new Error(`CRM request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+async function getByPhone(tenant, phone) {
+  return request(tenant, `/contacts/phone/${encodeURIComponent(phone)}`);
+}
+
+async function getByExternalId(tenant, externalId) {
+  return request(tenant, `/contacts/${encodeURIComponent(externalId)}`);
+}
+
+async function getOrderById(tenant, orderId) {
+  return request(tenant, `/orders/${encodeURIComponent(orderId)}`);
+}
+
+module.exports = { getByPhone, getByExternalId, getOrderById };

--- a/server/services/queue.js
+++ b/server/services/queue.js
@@ -1,0 +1,56 @@
+const crypto = require('crypto');
+
+let redisClient;
+let redisAvailable = false;
+
+try {
+  const redis = require('redis');
+  redisClient = redis.createClient({ url: process.env.REDIS_URL });
+  redisClient.connect().then(() => {
+    redisAvailable = true;
+  }).catch(() => {
+    redisAvailable = false;
+  });
+} catch (err) {
+  redisClient = null;
+}
+
+const memoryLocks = new Map();
+
+async function lock(key, ttl = 30000) {
+  const token = crypto.randomUUID();
+
+  if (redisClient && redisAvailable) {
+    const result = await redisClient.set(key, token, { NX: true, PX: ttl });
+    if (result === 'OK') {
+      return token;
+    }
+    return null;
+  }
+
+  const now = Date.now();
+  const current = memoryLocks.get(key);
+  if (current && current.expire > now) {
+    return null;
+  }
+
+  memoryLocks.set(key, { token, expire: now + ttl });
+  return token;
+}
+
+async function unlock(key, token) {
+  if (redisClient && redisAvailable) {
+    const value = await redisClient.get(key);
+    if (value === token) {
+      await redisClient.del(key);
+    }
+    return;
+  }
+
+  const current = memoryLocks.get(key);
+  if (current && current.token === token) {
+    memoryLocks.delete(key);
+  }
+}
+
+module.exports = { lock, unlock };

--- a/server/services/state.js
+++ b/server/services/state.js
@@ -1,0 +1,20 @@
+const queue = require('./queue');
+
+const states = new Map();
+
+async function upsert(conversationId, data = {}) {
+  const existing = states.get(conversationId) || {};
+  const newState = { ...existing, ...data, updatedAt: new Date().toISOString() };
+  states.set(conversationId, newState);
+  return newState;
+}
+
+async function lock(conversationId, ttl = 30000) {
+  return queue.lock(`state:${conversationId}`, ttl);
+}
+
+async function release(conversationId, token) {
+  return queue.unlock(`state:${conversationId}`, token);
+}
+
+module.exports = { upsert, lock, release };


### PR DESCRIPTION
## Summary
- add CRM service for retrieving contacts and orders
- add state service with upsert and locking support
- introduce Redis-backed queue locking helper with in-memory fallback

## Testing
- `node -e "require('./server/services/queue.js'); require('./server/services/state.js'); require('./server/services/crm.js'); console.log('modules loaded')"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13a12c3ec832abe07e455cdba17a0