### PR TITLE
Add server routes and middleware setup

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,18 +1,63 @@
 const express = require('express');
+const helmet = require('helmet');
+const morgan = require('morgan');
+const bodyParser = require('body-parser');
+const cors = require('./lib/cors');
+const rateLimit = require('./lib/rateLimit');
 const tenantResolver = require('./lib/tenantResolver');
 const { verifyTwilioSignature } = require('./services/security');
+const mongoose = require('mongoose');
+
+// route modules
+const agents = require('./routes/agents');
+const customers = require('./routes/customers');
+const tasks = require('./routes/tasks');
+const ai = require('./routes/ai');
+const tokens = require('./routes/tokens');
+const twilioWebhooks = require('./routes/twilio.webhooks');
 
 const app = express();
 
-// parse incoming webhook bodies
-app.use(express.urlencoded({ extended: false }));
-app.use(express.json());
-
-// resolve tenant from header before handling routes
+// global middlewares
+app.use(helmet());
+app.use(morgan('combined'));
+app.use(cors);
+app.use(rateLimit);
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use(tenantResolver);
 
-// verify twilio requests for webhook endpoints
-app.use('/webhooks', verifyTwilioSignature);
+// routes
+app.use('/agents', agents);
+app.use('/customers', customers);
+app.use('/tasks', tasks);
+app.use('/ai', ai);
+app.use('/tokens', tokens);
+app.use('/webhooks/twilio', verifyTwilioSignature, twilioWebhooks);
 
-// routes would be added below
+// centralized error handler
+app.use((err, req, res, next) => {
+  console.error(err); // eslint-disable-line no-console
+  res.status(err.status || 500).json({ error: err.message || 'Internal Server Error' });
+});
+
 module.exports = app;
+
+// Connect to Mongo and start server if run directly
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  const MONGO_URL = process.env.MONGO_URL || 'mongodb://localhost/nonflex';
+  mongoose
+    .connect(MONGO_URL)
+    .then(() => {
+      app.listen(PORT, () => {
+        // eslint-disable-next-line no-console
+        console.log(`Server listening on port ${PORT}`);
+      });
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('Mongo connection error', err);
+      process.exit(1);
+    });
+}

--- a/server/routes/agents.js
+++ b/server/routes/agents.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const Agent = require('../models/Agent');
+const { sign } = require('../lib/auth');
+
+const router = express.Router();
+
+// Agent login returning JWT
+router.post('/login', async (req, res, next) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
+
+  try {
+    const agent = await Agent.findOne({ username });
+    if (!agent) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const valid = await bcrypt.compare(password, agent.passwordHash);
+    if (!valid) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = sign({ id: agent._id, username: agent.username, roles: agent.roles });
+    res.json({ token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const { auth } = require('../lib/auth');
+const aiProvider = require('../services/aiProvider');
+
+const router = express.Router();
+
+// Generate AI reply for a user message
+router.post('/reply', auth, async (req, res, next) => {
+  const { userMsg, fromPhone } = req.body;
+  if (!userMsg) {
+    return res.status(400).json({ error: 'userMsg required' });
+  }
+  try {
+    const reply = await aiProvider.generateReply({
+      tenant: req.tenant,
+      userMsg,
+      fromPhone,
+    });
+    res.json({ reply });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const CRM = require('../services/crm');
+
+const router = express.Router();
+
+// Retrieve customer by phone number
+router.get('/phone/:phone', async (req, res, next) => {
+  try {
+    const customer = await CRM.getByPhone(req.tenant, req.params.phone);
+    res.json(customer);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Retrieve customer by external ID
+router.get('/:id', async (req, res, next) => {
+  try {
+    const customer = await CRM.getByExternalId(req.tenant, req.params.id);
+    res.json(customer);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const state = require('../services/state');
+
+const router = express.Router();
+
+// Claim a conversation/task by acquiring a lock
+router.post('/claim', async (req, res, next) => {
+  const { conversationId } = req.body;
+  if (!conversationId) {
+    return res.status(400).json({ error: 'conversationId required' });
+  }
+  try {
+    const token = await state.lock(conversationId);
+    if (!token) {
+      return res.status(409).json({ error: 'Task already claimed' });
+    }
+    await state.upsert(conversationId, { locked: true });
+    res.json({ token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Release a previously claimed conversation/task
+router.post('/release', async (req, res, next) => {
+  const { conversationId, token } = req.body;
+  if (!conversationId || !token) {
+    return res.status(400).json({ error: 'conversationId and token required' });
+  }
+  try {
+    await state.release(conversationId, token);
+    await state.upsert(conversationId, { locked: false });
+    res.json({ released: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/tokens.js
+++ b/server/routes/tokens.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const twilio = require('twilio');
+
+const router = express.Router();
+
+router.post('/', (req, res, next) => {
+  const { identity, room, serviceSid } = req.body;
+  try {
+    const accountSid = req.tenant?.twilioAccountSid || process.env.TWILIO_ACCOUNT_SID;
+    const apiKey = req.tenant?.twilioApiKey || process.env.TWILIO_API_KEY;
+    const apiSecret = req.tenant?.twilioApiSecret || process.env.TWILIO_API_SECRET;
+
+    if (!identity || !accountSid || !apiKey || !apiSecret) {
+      return res.status(400).json({ error: 'Missing credentials or identity' });
+    }
+
+    const AccessToken = twilio.jwt.AccessToken;
+    const token = new AccessToken(accountSid, apiKey, apiSecret, { identity });
+
+    if (serviceSid) {
+      const ChatGrant = AccessToken.ChatGrant;
+      token.addGrant(new ChatGrant({ serviceSid }));
+    }
+
+    if (room) {
+      const VideoGrant = AccessToken.VideoGrant;
+      token.addGrant(new VideoGrant({ room }));
+    }
+
+    res.json({ token: token.toJwt() });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/routes/twilio.webhooks.js
+++ b/server/routes/twilio.webhooks.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const twilio = require('twilio');
+const { generateReply } = require('../services/aiProvider');
+const { makeTwilioClients } = require('../services/twilio');
+const state = require('../services/state');
+
+const router = express.Router();
+
+// Handle incoming messages from Twilio Conversations
+router.post('/conversations', async (req, res, next) => {
+  const { ConversationSid, Body, Author, From } = req.body;
+
+  try {
+    // avoid responding to our own messages
+    if (!Body || Author === 'bot') {
+      return res.sendStatus(200);
+    }
+
+    // generate AI reply and send back via Twilio Conversations
+    const reply = await generateReply({
+      tenant: req.tenant,
+      userMsg: Body,
+      fromPhone: From,
+    });
+
+    if (reply) {
+      const { client } = makeTwilioClients(req.tenant);
+      await client.conversations.v1
+        .conversations(ConversationSid)
+        .messages.create({ author: 'bot', body: reply });
+    }
+
+    // store latest state
+    await state.upsert(ConversationSid, { lastInbound: Body });
+
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Simple voice webhook returning basic TwiML
+router.post('/voice', (req, res) => {
+  const response = new twilio.twiml.VoiceResponse();
+  response.say('Thank you for calling. Please hold while we connect you.');
+  res.type('text/xml');
+  res.send(response.toString());
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Express middlewares and Mongo startup logic
- implement routes for agents, tasks, customers, AI replies, tokens, and Twilio webhooks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13df00138832a97cc8da7a14e2f25