### PR TITLE
Add community guidelines and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ web_modules/
 .next
 out
 
+# Create React App build output
+build
+
 # Nuxt.js build / generate output
 .nuxt
 dist
@@ -137,3 +140,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Misc
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Nonflex
+
+Thanks for taking the time to contribute!
+
+## Coding Standards
+- Use two spaces for indentation and keep lines under 100 characters.
+- Prefer `const`/`let` over `var`.
+- Include semicolons and follow existing code style.
+- Run any available linters or formatters before committing.
+
+## Local Development Setup
+1. **Install dependencies**
+   ```bash
+   npm install
+   cd client && npm install
+   ```
+2. **Configure environment**
+   ```bash
+   cp .env.example .env
+   ```
+   Fill in the required values noted in the README.
+3. **Optional: seed the database**
+   ```bash
+   npm run seed
+   ```
+4. **Start the services**
+   - Backend: `node server/app.js`
+   - Frontend: `cd client && npm run dev`
+
+## Pull Request Process
+- Fork the repository and create your branch from `main`.
+- Keep commits focused and include clear messages.
+- Run `npm test` before submitting your PR.
+- Open a pull request describing your changes and any testing performed.
+
+We appreciate your contributions!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Nonflex contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "dependencies": {
     "bcryptjs": "^3.0.2",


### PR DESCRIPTION
## Summary
- add MIT license and contribution guidelines
- expand gitignore for React build and macOS artifacts
- set package.json license to MIT

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a15394aedc832aac413325157c5fd8