### PR TITLE
feat: expose more twilio helpers

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const state = require('../services/state');
+const { makeTwilioClients } = require('../services/twilio');
 
 const router = express.Router();
 
@@ -14,8 +15,9 @@ router.post('/claim', async (req, res, next) => {
     if (!token) {
       return res.status(409).json({ error: 'Task already claimed' });
     }
+    const { voiceFrom, waFrom } = makeTwilioClients(req.tenant);
     await state.upsert(conversationId, { locked: true });
-    res.json({ token });
+    res.json({ token, voiceFrom, waFrom });
   } catch (err) {
     next(err);
   }

--- a/server/routes/twilio.webhooks.js
+++ b/server/routes/twilio.webhooks.js
@@ -24,8 +24,8 @@ router.post('/conversations', async (req, res, next) => {
     });
 
     if (reply) {
-      const { client } = makeTwilioClients(req.tenant);
-      await client.conversations.v1
+      const { conversations } = makeTwilioClients(req.tenant);
+      await conversations.v1
         .conversations(ConversationSid)
         .messages.create({ author: 'bot', body: reply });
     }

--- a/server/services/twilio.js
+++ b/server/services/twilio.js
@@ -3,17 +3,32 @@ const twilio = require('twilio');
 /**
  * Create Twilio REST clients for a tenant.
  * @param {Object} tenant - Tenant configuration containing Twilio credentials.
- * @returns {Object} Object containing the Twilio client instance.
+ * @returns {Object} Object containing the Twilio client instance and helpers.
  */
 function makeTwilioClients(tenant = {}) {
-  const { accountSid, authToken } = tenant.twilio || {};
+  const {
+    accountSid,
+    authToken,
+    workspaceSid,
+    voiceNumber,
+    whatsappNumber,
+  } = tenant.twilio || {};
 
   if (!accountSid || !authToken) {
     throw new Error('Twilio credentials are not configured for tenant');
   }
 
   const client = twilio(accountSid, authToken);
-  return { client };
+  const taskrouter = workspaceSid
+    ? client.taskrouter.workspaces(workspaceSid)
+    : null;
+  const conversations = client.conversations;
+  const video = client.video;
+
+  const voiceFrom = voiceNumber;
+  const waFrom = whatsappNumber;
+
+  return { client, taskrouter, conversations, video, voiceFrom, waFrom };
 }
 
 module.exports = { makeTwilioClients };


### PR DESCRIPTION
## Summary
- expose taskrouter, conversations, video and number helpers via `makeTwilioClients`
- use conversation client helper in Twilio webhook
- surface configured voice and WhatsApp numbers when claiming tasks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a15cf3d01c832abe68c406fe64d74f