### PR TITLE
Add conversations and video token routes

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,7 @@ const agents = require('./routes/agents');
 const customers = require('./routes/customers');
 const tasks = require('./routes/tasks');
 const ai = require('./routes/ai');
-const tokens = require('./routes/tokens');
+const tokenRoutes = require('./routes/tokens');
 const twilioWebhooks = require('./routes/twilio.webhooks');
 
 const app = express();
@@ -32,7 +32,7 @@ app.use('/agents', agents);
 app.use('/customers', customers);
 app.use('/tasks', tasks);
 app.use('/ai', ai);
-app.use('/tokens', tokens);
+app.use('/tokens', tokenRoutes);
 app.use('/webhooks/twilio', verifyTwilioSignature, twilioWebhooks);
 
 // centralized error handler

--- a/server/routes/tokens.js
+++ b/server/routes/tokens.js
@@ -3,28 +3,65 @@ const twilio = require('twilio');
 
 const router = express.Router();
 
-router.post('/', (req, res, next) => {
-  const { identity, room, serviceSid } = req.body;
-  try {
-    const { accountSid, apiKey, apiSecret, conversationsServiceSid } = req.tenant?.twilio || {};
+function getTwilioConfig(req) {
+  const {
+    accountSid = process.env.TWILIO_ACCOUNT_SID,
+    apiKey: apiKeySid = process.env.TWILIO_API_KEY,
+    apiSecret: apiKeySecret = process.env.TWILIO_API_SECRET,
+    conversationsServiceSid = process.env.TWILIO_CONVERSATIONS_SERVICE_SID,
+  } = req.tenant?.twilio || {};
+  return { accountSid, apiKeySid, apiKeySecret, conversationsServiceSid };
+}
 
-    if (!identity || !accountSid || !apiKey || !apiSecret) {
+router.post('/conversations', (req, res, next) => {
+  const { identity } = req.body;
+  try {
+    const {
+      accountSid,
+      apiKeySid,
+      apiKeySecret,
+      conversationsServiceSid,
+    } = getTwilioConfig(req);
+
+    if (
+      !identity ||
+      !accountSid ||
+      !apiKeySid ||
+      !apiKeySecret ||
+      !conversationsServiceSid
+    ) {
       return res.status(400).json({ error: 'Missing credentials or identity' });
     }
 
     const AccessToken = twilio.jwt.AccessToken;
-    const token = new AccessToken(accountSid, apiKey, apiSecret, { identity });
+    const token = new AccessToken(accountSid, apiKeySid, apiKeySecret, { identity });
 
-    const chatSid = serviceSid || conversationsServiceSid;
-    if (chatSid) {
-      const ChatGrant = AccessToken.ChatGrant;
-      token.addGrant(new ChatGrant({ serviceSid: chatSid }));
+    const ConversationsGrant = AccessToken.ConversationsGrant || AccessToken.ChatGrant;
+    if (!ConversationsGrant) {
+      return res.status(500).json({ error: 'Conversations grant not supported' });
+    }
+    token.addGrant(new ConversationsGrant({ serviceSid: conversationsServiceSid }));
+
+    res.json({ token: token.toJwt() });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/video', (req, res, next) => {
+  const { identity, room } = req.body;
+  try {
+    const { accountSid, apiKeySid, apiKeySecret } = getTwilioConfig(req);
+
+    if (!identity || !accountSid || !apiKeySid || !apiKeySecret) {
+      return res.status(400).json({ error: 'Missing credentials or identity' });
     }
 
-    if (room) {
-      const VideoGrant = AccessToken.VideoGrant;
-      token.addGrant(new VideoGrant({ room }));
-    }
+    const AccessToken = twilio.jwt.AccessToken;
+    const token = new AccessToken(accountSid, apiKeySid, apiKeySecret, { identity });
+
+    const VideoGrant = AccessToken.VideoGrant;
+    token.addGrant(new VideoGrant(room ? { room } : undefined));
 
     res.json({ token: token.toJwt() });
   } catch (err) {
@@ -33,3 +70,4 @@ router.post('/', (req, res, next) => {
 });
 
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- Provide separate `/tokens/conversations` and `/tokens/video` endpoints
- Allow identity and room parameters, pulling Twilio credentials from env or tenant config
- Mount new token routes in server app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a165bc540c832ab915b50a2ffa711c