### PR TITLE
Add JWT auth and Twilio AI toggle for task routes

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,8 +1,24 @@
 const express = require('express');
 const state = require('../services/state');
 const { makeTwilioClients } = require('../services/twilio');
+const { auth } = require('../lib/auth');
 
 const router = express.Router();
+
+// All task routes require JWT auth
+router.use(auth);
+
+// Placeholder route for creating a task via TaskRouter
+router.post('/create', (req, res) => {
+  // TODO: integrate with TaskRouter to create tasks
+  res.status(501).json({ error: 'Not implemented' });
+});
+
+// Placeholder route for listing tasks from TaskRouter
+router.get('/list', (req, res) => {
+  // TODO: integrate with TaskRouter to list tasks
+  res.json({ tasks: [] });
+});
 
 // Claim a conversation/task by acquiring a lock
 router.post('/claim', async (req, res, next) => {
@@ -15,8 +31,17 @@ router.post('/claim', async (req, res, next) => {
     if (!token) {
       return res.status(409).json({ error: 'Task already claimed' });
     }
-    const { voiceFrom, waFrom } = makeTwilioClients(req.tenant);
-    await state.upsert(conversationId, { locked: true });
+    const { conversations, voiceFrom, waFrom } = makeTwilioClients(req.tenant);
+    const convo = await conversations.v1.conversations(conversationId).fetch();
+    const attrs = convo.attributes ? JSON.parse(convo.attributes) : {};
+    attrs.aiEnabled = false;
+    await conversations.v1
+      .conversations(conversationId)
+      .update({ attributes: JSON.stringify(attrs) });
+    await state.upsert(conversationId, {
+      locked: true,
+      lockedBy: req.user && req.user.sub,
+    });
     res.json({ token, voiceFrom, waFrom });
   } catch (err) {
     next(err);
@@ -25,13 +50,20 @@ router.post('/claim', async (req, res, next) => {
 
 // Release a previously claimed conversation/task
 router.post('/release', async (req, res, next) => {
-  const { conversationId, token } = req.body;
+  const { conversationId, token, aiEnabled = true } = req.body;
   if (!conversationId || !token) {
     return res.status(400).json({ error: 'conversationId and token required' });
   }
   try {
+    const { conversations } = makeTwilioClients(req.tenant);
+    const convo = await conversations.v1.conversations(conversationId).fetch();
+    const attrs = convo.attributes ? JSON.parse(convo.attributes) : {};
+    attrs.aiEnabled = aiEnabled;
+    await conversations.v1
+      .conversations(conversationId)
+      .update({ attributes: JSON.stringify(attrs) });
     await state.release(conversationId, token);
-    await state.upsert(conversationId, { locked: false });
+    await state.upsert(conversationId, { locked: false, lockedBy: null });
     res.json({ released: true });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- secure task endpoints with JWT auth
- add placeholders for TaskRouter task creation and listing
- toggle Twilio Conversations AI on claim and release while tracking lock ownership

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a165cec9d8832a91f613515813041b