### PR TITLE
Persist conversation state with Mongo

### DIFF
--- a/server/models/ConversationState.js
+++ b/server/models/ConversationState.js
@@ -1,9 +1,13 @@
 const mongoose = require('mongoose');
 
 const ConversationStateSchema = new mongoose.Schema({
-  conversationId: { type: String, required: true, unique: true },
+  tenant: { type: String, required: true, index: true },
+  conversationId: { type: String, required: true },
   attributes: { type: mongoose.Schema.Types.Mixed },
-  locked: { type: Boolean, default: false },
+  aiEnabled: { type: Boolean, default: true },
+  lockedBy: { type: String, default: null },
 }, { timestamps: true });
+
+ConversationStateSchema.index({ tenant: 1, conversationId: 1 }, { unique: true });
 
 module.exports = mongoose.model('ConversationState', ConversationStateSchema);

--- a/server/routes/twilio.webhooks.js
+++ b/server/routes/twilio.webhooks.js
@@ -30,8 +30,8 @@ router.post('/conversations', async (req, res, next) => {
         .messages.create({ author: 'bot', body: reply });
     }
 
-    // store latest state
-    await state.upsert(ConversationSid, { lastInbound: Body });
+      // store latest state scoped to tenant
+      await state.upsert(req.tenantId, ConversationSid, { lastInbound: Body });
 
     res.sendStatus(200);
   } catch (err) {


### PR DESCRIPTION
## Summary
- persist conversation state in Mongo including tenant, aiEnabled, and lockedBy fields
- add Mongo-backed upsert, lock, and release helpers
- update webhooks and task routes to use tenant-scoped state API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a165d0f464832a8b037a0db001e326