### PR TITLE
Document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,22 @@
 # Server configuration
+# Port for the Express server
 PORT=3000
-MONGO_URI=mongodb://localhost/nonflex
+# MongoDB connection string
 MONGO_URL=mongodb://localhost/nonflex
+# Secret used to sign JWTs
 JWT_SECRET=changeme
+# Default tenant id when none is supplied
 DEFAULT_TENANT=default
+# Allowed origin for CORS (frontend URL)
 CLIENT_URL=http://localhost:3000
+# Base public URL of this service for webhooks
+PUBLIC_URL=http://localhost:3000
+# Redis connection string
 REDIS_URL=redis://localhost:6379
+# Base URL of external CRM
 CRM_BASE_URL=https://api.example-crm.com
+# API key for the CRM
 CRM_API_KEY=your-crm-api-key
+# Twilio API credentials for generating access tokens
+TWILIO_API_KEY_SID=your-twilio-api-key-sid
+TWILIO_API_KEY_SECRET=your-twilio-api-key-secret

--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ Copy `.env.example` to `.env` and adjust the values as needed:
 | Variable | Description |
 | --- | --- |
 | `PORT` | Server port (default 3000). |
-| `MONGO_URI` / `MONGO_URL` | MongoDB connection string. |
+| `MONGO_URL` | MongoDB connection string. |
 | `JWT_SECRET` | Secret used to sign JWTs. |
 | `DEFAULT_TENANT` | Default tenant id when none supplied. |
 | `CLIENT_URL` | Allowed origin for CORS. |
+| `PUBLIC_URL` | Base public URL of the service. |
 | `REDIS_URL` | Redis connection string. |
 | `CRM_BASE_URL` | Base URL of external CRM. |
 | `CRM_API_KEY` | API key for the CRM. |
+| `TWILIO_API_KEY_SID` | Twilio API Key SID for access tokens. |
+| `TWILIO_API_KEY_SECRET` | Twilio API Key Secret for access tokens. |
 
 ## Required Twilio Resources
 


### PR DESCRIPTION
## Summary
- expand `.env.example` with comments and placeholders for PUBLIC_URL and Twilio API keys
- drop unused MONGO_URI example and clarify `MONGO_URL` in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a165d4fdf0832a9d486423d7815614