### PR TITLE
feat: add agent level and status management

### DIFF
--- a/infra/seed.js
+++ b/infra/seed.js
@@ -31,6 +31,8 @@ async function seed() {
         skills: ['support', 'sales'],
         languages: ['en', 'es'],
         roles: ['agent'],
+        level: 1,
+        status: 'offline',
       },
     ];
 
@@ -43,6 +45,8 @@ async function seed() {
         languages: a.languages,
         roles: a.roles,
         tenant: TENANT,
+        level: a.level,
+        status: a.status,
       });
     }
 

--- a/server/models/Agent.js
+++ b/server/models/Agent.js
@@ -7,6 +7,8 @@ const AgentSchema = new mongoose.Schema({
   languages: [String],
   roles: [String],
   tenant: { type: String, required: true },
+  level: { type: Number, default: 1 },
+  status: { type: String, enum: ['available', 'busy', 'offline'], default: 'offline' },
 }, { timestamps: true });
 
 export default mongoose.model('Agent', AgentSchema);

--- a/server/routes/agents.js
+++ b/server/routes/agents.js
@@ -34,4 +34,36 @@ router.post('/login', async (req, res, next) => {
   }
 });
 
+// Update agent status
+router.patch('/:id/status', async (req, res, next) => {
+  const { status } = req.body;
+  if (!status || !['available', 'busy', 'offline'].includes(status)) {
+    return res.status(400).json({ error: 'invalid status' });
+  }
+  try {
+    const query = req.tenantId ? { _id: req.params.id, tenant: req.tenantId } : { _id: req.params.id };
+    const agent = await Agent.findOneAndUpdate(query, { status }, { new: true, fields: 'status level' });
+    if (!agent) {
+      return res.status(404).json({ error: 'Agent not found' });
+    }
+    res.json({ status: agent.status });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Retrieve agent level
+router.get('/:id/level', async (req, res, next) => {
+  try {
+    const query = req.tenantId ? { _id: req.params.id, tenant: req.tenantId } : { _id: req.params.id };
+    const agent = await Agent.findOne(query, 'level');
+    if (!agent) {
+      return res.status(404).json({ error: 'Agent not found' });
+    }
+    res.json({ level: agent.level });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add `level` and `status` fields to Agent model
- seed initial agents with level and status
- add endpoints to update agent status and read agent level

## Testing
- `npm test`
- `npm test --workspace server`

------
https://chatgpt.com/codex/tasks/task_e_68a2444ec328832a926f5320bce827ad