### PR TITLE
docs: add env variable samples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,31 @@
 # Root workspace environment variables
+# Copy this file to .env and adjust the values as needed.
+
+# Twilio Account SID
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Twilio Auth Token
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+
+# Twilio API Key SID used for generating access tokens
+TWILIO_API_KEY=SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Twilio API Key Secret used for generating access tokens
+TWILIO_API_SECRET=your_twilio_api_secret
+
+# Twilio Conversations Service SID
+TWILIO_CONVERSATIONS_SERVICE_SID=ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# OpenAI API key for AI features
+OPENAI_API_KEY=sk-your-openai-key
+
+# Secret used to sign JWTs
+JWT_SECRET=super_secret
+
+# Redis connection string
+REDIS_URL=redis://localhost:6379
+
+# Default tenant id if X-Tenant-Id header is missing
+DEFAULT_TENANT=tenant1
+
 # See server/.env.example and client/.env.example for service-specific settings.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ Copy `.env.example` to `.env` and adjust the values as needed:
 | `REDIS_URL` | Redis connection string. |
 | `CRM_BASE_URL` | Base URL of external CRM. |
 | `CRM_API_KEY` | API key for the CRM. |
-| `TWILIO_API_KEY_SID` | Twilio API Key SID for access tokens. |
-| `TWILIO_API_KEY_SECRET` | Twilio API Key Secret for access tokens. |
+| `TWILIO_ACCOUNT_SID` | Twilio Account SID. |
+| `TWILIO_AUTH_TOKEN` | Twilio Auth Token. |
+| `TWILIO_API_KEY` | Twilio API Key SID for access tokens. |
+| `TWILIO_API_SECRET` | Twilio API Key Secret for access tokens. |
+| `TWILIO_CONVERSATIONS_SERVICE_SID` | Twilio Conversations Service SID. |
+| `OPENAI_API_KEY` | OpenAI API key for AI features. |
 
 ## Required Twilio Resources
 


### PR DESCRIPTION
## Summary
- document Twilio, OpenAI, JWT, Redis, and tenant variables in env example
- sync README with root env variables for setup guidance

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a24459216c832aae35a9dffc319890