### PR TITLE
feat: add agent status endpoints

### DIFF
--- a/server/models/Agent.js
+++ b/server/models/Agent.js
@@ -5,6 +5,7 @@ const AgentSchema = new mongoose.Schema({
   passwordHash: { type: String, required: true },
   skills: [String],
   languages: [String],
+  status: { type: String, default: 'offline' },
   roles: [String],
   tenant: { type: String, required: true },
 }, { timestamps: true });

--- a/server/routes/agents.js
+++ b/server/routes/agents.js
@@ -1,7 +1,8 @@
 import express from 'express';
 import bcrypt from 'bcryptjs';
 import Agent from '../models/Agent.js';
-import { sign } from '../lib/auth.js';
+import { sign, auth } from '../lib/auth.js';
+import { requireRole } from '../lib/rbac.js';
 
 const router = express.Router();
 
@@ -29,6 +30,45 @@ router.post('/login', async (req, res, next) => {
       tenant: agent.tenant,
     });
     res.json({ token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Get current authenticated agent info
+router.get('/me', auth, requireRole('agent'), async (req, res, next) => {
+  try {
+    const agent = await Agent.findById(req.user.id);
+    if (!agent) {
+      return res.status(404).json({ error: 'Agent not found' });
+    }
+    res.json({
+      id: agent._id.toString(),
+      username: agent.username,
+      status: agent.status,
+      skills: agent.skills,
+      languages: agent.languages,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Update availability status for an agent
+router.post('/:id/status', auth, requireRole('agent'), async (req, res, next) => {
+  if (req.user.id !== req.params.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const { status } = req.body;
+  if (!status) {
+    return res.status(400).json({ error: 'status required' });
+  }
+  try {
+    const agent = await Agent.findByIdAndUpdate(req.params.id, { status }, { new: true });
+    if (!agent) {
+      return res.status(404).json({ error: 'Agent not found' });
+    }
+    res.json({ id: agent._id.toString(), status: agent.status });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- add status field to Agent model
- expose /agents/me and /agents/:id/status endpoints with role verification

## Testing
- `npm test --workspaces` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2445cbcdc832a8f4583bc5e454aae