### PR TITLE
Add agent self-status endpoints with RBAC and skill/language exposure

### DIFF
--- a/server/services/agentStatus.js
+++ b/server/services/agentStatus.js
@@ -1,0 +1,11 @@
+const cache = new Map();
+
+export function get(id) {
+  return cache.get(id);
+}
+
+export function set(id, data) {
+  cache.set(id, data);
+}
+
+export default { get, set };


### PR DESCRIPTION
## Summary
- add `/agents/me` to fetch the authenticated agent's status, skills, and languages
- support updating availability via `POST /agents/:id/status` with role checks and caching
- introduce simple in-memory agent status cache service

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a24b984c14832a8c6f353e477bdca9