### PR TITLE
feat: resolve tenant via subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ own flexible customer‑care platform.
 ### Backend (`server/`)
 - Node.js + Express service exposing routes for agents, customers, tasks, AI and
   Twilio webhooks.
-- Middleware `tenantResolver` reads an `X-Tenant-Id` header and attaches
-  tenant configuration from `infra/tenants.json`, including `twilio` and optional `ai` sections.
+- Middleware `tenantResolver` resolves the tenant from the request subdomain or an `X-Tenant-Id` header (subdomain wins) and
+  attaches tenant configuration from `infra/tenants.json`, including `twilio` and optional `ai` sections.
 - Connects to MongoDB, Redis, external CRM and Twilio APIs.
 
 ### Frontend (`client/`)
@@ -26,7 +26,8 @@ own flexible customer‑care platform.
 
 ### Multi-tenant approach
 - Tenants are defined in `infra/tenants.json`.
-- API requests include an `X-Tenant-Id` header to select the tenant.
+- The server determines the tenant using the request subdomain (e.g., `<tenant>.example.com`) or an `X-Tenant-Id` header.
+- Subdomains take precedence; when neither is provided, `DEFAULT_TENANT` is used.
 - Each tenant supplies unique CRM, Twilio, and optional AI credentials via configuration.
 
 ## Environment Variables

--- a/server/lib/tenantResolver.js
+++ b/server/lib/tenantResolver.js
@@ -1,7 +1,9 @@
 import tenants from '../../infra/tenants.json' assert { type: 'json' };
 
 export default function tenantResolver(req, res, next) {
-  const tenantId = req.header('X-Tenant-Id') || process.env.DEFAULT_TENANT || null;
+  const hostTenantId = req.hostname && req.hostname.includes('.') ? req.hostname.split('.')[0] : null;
+  const headerTenantId = req.header('X-Tenant-Id');
+  const tenantId = hostTenantId || headerTenantId || process.env.DEFAULT_TENANT || null;
   req.tenantId = tenantId || null;
   const tenant = tenantId && tenants[tenantId] ? tenants[tenantId] : null;
   if (tenant) {


### PR DESCRIPTION
## Summary
- extract subdomain from request hostname as first choice for tenant resolution
- fall back to X-Tenant-Id header and DEFAULT_TENANT
- document subdomain and header tenant resolution options

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a364ffb9bc832a920576e3f3f94990