### PR TITLE
feat: persist conversation state

### DIFF
--- a/server/models/ConversationState.js
+++ b/server/models/ConversationState.js
@@ -6,4 +6,7 @@ const ConversationStateSchema = new mongoose.Schema({
   locked: { type: Boolean, default: false },
 }, { timestamps: true });
 
+// Index for quick lookups by conversationId
+ConversationStateSchema.index({ conversationId: 1 });
+
 export default mongoose.model('ConversationState', ConversationStateSchema);

--- a/server/services/state.js
+++ b/server/services/state.js
@@ -1,20 +1,45 @@
 import { lock as lockKey, unlock as unlockKey } from './queue.js';
 import audit from './audit.js';
-
-const states = new Map();
+import ConversationState from '../models/ConversationState.js';
 
 export async function upsert(conversationId, data = {}) {
-  const existing = states.get(conversationId) || {};
-  const newState = { ...existing, ...data, updatedAt: new Date().toISOString() };
-  states.set(conversationId, newState);
-  audit.log('state.update', { conversationId, state: newState });
-  return newState;
+  const { locked, ...attrs } = data;
+  const update = {};
+  // Persist arbitrary attributes under the `attributes` field
+  for (const [key, value] of Object.entries(attrs)) {
+    update[`attributes.${key}`] = value;
+  }
+  if (typeof locked === 'boolean') {
+    update.locked = locked;
+  }
+
+  const doc = await ConversationState.findOneAndUpdate(
+    { conversationId },
+    { $set: update },
+    { upsert: true, new: true, setDefaultsOnInsert: true, lean: true }
+  );
+
+  const state = { ...(doc.attributes || {}), locked: doc.locked, updatedAt: doc.updatedAt };
+  audit.log('state.update', { conversationId, state });
+  return state;
 }
 
 export async function lock(conversationId, ttl = 30000) {
-  return lockKey(`state:${conversationId}`, ttl);
+  const token = await lockKey(`state:${conversationId}`, ttl);
+  if (token) {
+    await ConversationState.findOneAndUpdate(
+      { conversationId },
+      { $set: { locked: true } },
+      { upsert: true }
+    );
+  }
+  return token;
 }
 
 export async function release(conversationId, token) {
-  return unlockKey(`state:${conversationId}`, token);
+  await unlockKey(`state:${conversationId}`, token);
+  await ConversationState.findOneAndUpdate(
+    { conversationId },
+    { $set: { locked: false } }
+  );
 }


### PR DESCRIPTION
## Summary
- replace in-memory state tracking with ConversationState model
- persist lock/release status in database
- index ConversationState by conversationId for faster lookups

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a365047be8832aa1f5f13b0fd18a3c