### PR TITLE
Añadir prompt en español y handoff por reembolso o queja

### DIFF
--- a/server/services/aiProvider.js
+++ b/server/services/aiProvider.js
@@ -12,7 +12,7 @@ function getClient(tenant = {}) {
 }
 
 function buildSystemPrompt(customer) {
-  let prompt = 'You are a helpful customer support assistant. Use the provided context to answer user messages accurately and concisely. If the question is outside of your knowledge or violates policy, respond that you cannot help.';
+  let prompt = 'Eres un asistente de soporte para Acme Retail. Responde en español de forma precisa y concisa utilizando la información disponible. Si el cliente presenta una queja, solicita un reembolso o faltan datos para ayudarle, debes transferir la conversación a un agente humano.';
   if (customer) {
     const parts = [];
     if (customer.name) parts.push(`Name: ${customer.name}`);

--- a/server/services/aiProvider.test.js
+++ b/server/services/aiProvider.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateReply } from './aiProvider.js';
+import { checkContent } from './contentFilter.js';
+
+test('contentFilter forces handoff on reembolso', () => {
+  const res = checkContent('Necesito un reembolso');
+  assert.equal(res.allowed, false);
+  assert.equal(res.handoff, true);
+});
+
+test('contentFilter forces handoff on queja', () => {
+  const res = checkContent('Tengo una queja');
+  assert.equal(res.allowed, false);
+  assert.equal(res.handoff, true);
+});
+
+test('generateReply disables AI on reembolso', async () => {
+  const res = await generateReply({ userMsg: 'Necesito un reembolso' });
+  assert.equal(res.handoff, true);
+  assert.equal(res.reply, '');
+});
+
+test('generateReply disables AI on queja', async () => {
+  const res = await generateReply({ userMsg: 'Presento una queja' });
+  assert.equal(res.handoff, true);
+  assert.equal(res.reply, '');
+});

--- a/server/services/contentFilter.js
+++ b/server/services/contentFilter.js
@@ -4,7 +4,7 @@ const piiRegexes = [
 ];
 
 const offensiveWords = ['fuck','shit','idiot','stupid'];
-const handoffKeywords = ['agent','humano','human','representante','person'];
+const handoffKeywords = ['agent','humano','human','representante','person','reembolso','reembolsos','queja','quejas'];
 
 export function checkContent(text = '') {
   const lower = text.toLowerCase();


### PR DESCRIPTION
## Summary
- Reemplaza el prompt por una versión en español para Acme Retail con reglas de handoff por quejas, reembolsos o falta de datos
- Detecta las palabras "reembolso" y "queja" en el filtro de contenido para forzar handoff
- Agrega pruebas unitarias para verificar que la IA se desactiva cuando se mencionan reembolsos o quejas

## Testing
- `node --test server/services/aiProvider.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a36506f6ac832a8deb23af3f3c5015